### PR TITLE
Upgrade Dawn.Guard to latest version

### DIFF
--- a/src/GraphQL.Query.Builder/GraphQL.Query.Builder.csproj
+++ b/src/GraphQL.Query.Builder/GraphQL.Query.Builder.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dawn.Guard" Version="1.0.0" />
+    <PackageReference Include="Dawn.Guard" Version="1.12.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Using this library with the latest version of Dawn.Guard (1.12.0) throws `MissingMethodException` because the signature of `Argument<T>` has changed across versions 😭 

I don't think there is any drawback to upgrade it, it makes no sense that someone using your library would prefer to be stuck with an old version of Dawn ☺️ 

Thank you! (et des bisous)