### PR TITLE
Fix the case when expression property base is an interface

### DIFF
--- a/src/GraphQL.Query.Builder/QueryOf{T}.cs
+++ b/src/GraphQL.Query.Builder/QueryOf{T}.cs
@@ -225,8 +225,13 @@ namespace GraphQL.Query.Builder
                 throw new ArgumentException($"Expression '{lambda.ToString()}' not refers to a property.");
             }
 
+            if (propertyInfo.ReflectedType == null)
+            {
+                throw new ArgumentException($"Expression '{lambda.ToString()}' not refers to a property.");
+            }
+
             Type type = typeof(TSource);
-            if (type != propertyInfo.ReflectedType && !type.IsSubclassOf(propertyInfo.ReflectedType))
+            if (type != propertyInfo.ReflectedType && !propertyInfo.ReflectedType.IsAssignableFrom(type))
             {
                 throw new ArgumentException($"Expression '{lambda.ToString()}' refers to a property that is not from type {type}.");
             }


### PR DESCRIPTION
Hey.
This should fix the case when current query type inherits from Iinterface and not concrete type.
In such case better to use IsAssignableFrom