### PR TITLE
Added QueryStringParam, which makes it possible to decide whether or not to surround a string parameter with quotes

### DIFF
--- a/src/GraphQL.Query.Builder/QueryStringBuilder.cs
+++ b/src/GraphQL.Query.Builder/QueryStringBuilder.cs
@@ -96,6 +96,9 @@ namespace GraphQL.Query.Builder
                     }
                     return $"[{string.Join(",", items)}]";
 
+                case QueryStringParam queryStringParam:
+                    return queryStringParam.SurroundWithQuotes ? $"\"{queryStringParam.Value}\"" : queryStringParam.Value;
+
                 default:
                     throw new InvalidDataException("Unsupported Query Parameter, Type Found : " + value.GetType());
             }

--- a/src/GraphQL.Query.Builder/QueryStringParam.cs
+++ b/src/GraphQL.Query.Builder/QueryStringParam.cs
@@ -1,0 +1,27 @@
+namespace GraphQL.Query.Builder
+{
+    /// <summary>
+    /// Class that makes it possible to decide whether or not to surround a string value parameter with double quotes
+    /// </summary>
+    public class QueryStringParam
+    {
+        /// <summary>
+        /// The string value to add to the query
+        /// </summary>
+        public string Value { get; set; }
+
+        /// <summary>
+        /// If set to true, the value will be surrounded with double quotes. Otherwise, no quotes will be added.
+        /// </summary>
+        public bool SurroundWithQuotes { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the QueryStringParam class.
+        /// </summary>
+        public QueryStringParam(string value, bool surroundWithQuotes = true)
+        {
+            Value = value;
+            SurroundWithQuotes = surroundWithQuotes;
+        }
+    }
+}


### PR DESCRIPTION
I had a use case where I needed to add string parameters to the query, but not have them surrounded with quotes. 
Example:
  ```
Items(where: { _search: "Search parameter" }) {
     ... values
}
```

This code makes it possible to supply adding a parameter of type QueryStringParam to the Query and using the SurroundWithBoolQuotes as an addition :)