### PR TITLE
Allow overrding the QueryStringBuilder.FormatQueryParam method

### DIFF
--- a/src/GraphQL.Query.Builder/QueryOptions.cs
+++ b/src/GraphQL.Query.Builder/QueryOptions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace GraphQL.Query.Builder
 {

--- a/src/GraphQL.Query.Builder/QueryStringBuilder.cs
+++ b/src/GraphQL.Query.Builder/QueryStringBuilder.cs
@@ -36,7 +36,7 @@ namespace GraphQL.Query.Builder
         /// <param name="value"></param>
         /// <returns>The formatted query param.</returns>
         /// <exception cref="InvalidDataException">Invalid Object Type in Param List</exception>
-        internal protected string FormatQueryParam(object value)
+        internal protected virtual string FormatQueryParam(object value)
         {
             switch (value)
             {

--- a/tests/GraphQL.Query.Builder.UnitTests/CustomQueryStringBuilderTests.cs
+++ b/tests/GraphQL.Query.Builder.UnitTests/CustomQueryStringBuilderTests.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Text;
+using Xunit;
+
+namespace GraphQL.Query.Builder.UnitTests
+{
+    public class CustomQueryStringBuilderTests
+    {
+        [Fact]
+        public void TestOverride()
+        {
+            string query = new Query<object>("something",
+                    new QueryOptions {QueryStringBuilderFactory = () => new ConstantCaseEnumQueryStringBuilder()})
+                .AddArgument("case", Cases.ConstantCase)
+                .AddField("some")
+                .Build();
+
+            Assert.Equal("something(case:CONSTANT_CASE){some}", query);
+        }
+
+        enum Cases
+        {
+            CamelCase,
+            PascalCase,
+            ConstantCase
+        }
+
+        class ConstantCaseEnumQueryStringBuilder : QueryStringBuilder
+        {
+            protected internal override string FormatQueryParam(object value) =>
+                value switch
+                {
+                    Enum e => this.ToConstantCase(e.ToString()),
+                    _ => base.FormatQueryParam(value)
+                };
+
+            private string ToConstantCase(string name)
+            {
+                var sb = new StringBuilder();
+                bool firstUpperLetter = true;
+                foreach (char c in name)
+                {
+                    if (char.IsUpper(c))
+                    {
+                        if (!firstUpperLetter)
+                        {
+                            sb.Append("_");
+                        }
+                        firstUpperLetter = false;
+                    }
+
+                    sb.Append(char.ToUpperInvariant(c));
+                }
+                string result = sb.ToString();
+
+                return result;
+            }
+        }
+    }
+}


### PR DESCRIPTION
We need to serialize enums named in the Pascal Case style to strings in the Constant Case style. As in the test, `Cases.ConstantCase` should serialize to `CONSTANT_CASE`. This configuration meets the criteria of C# and GraphQL naming standards.

`GraphQL.Query.Builder` allows configuring your own `IQueryStringBuilder`. I suggest making the `QueryStringBuilder.FormatQueryParam` method virtual. It will allow overriding the default behavior without code duplication. 